### PR TITLE
Add camera zoom and pan to 3D tools

### DIFF
--- a/src/react-app/hooks/useMCPGraph3DTools.ts
+++ b/src/react-app/hooks/useMCPGraph3DTools.ts
@@ -318,12 +318,16 @@ This creates a "big bang" or "collapse" effect:
 
       if (mode === "explode") {
         api.explodeView();
+        // Zoom out to show the expanded graph after explosion settles
+        setTimeout(() => api.zoomToFit(1200, 120), 500);
         toast.success("3D Graph: Exploded view");
-        return "💥 Graph exploded! Nodes pushed apart for dramatic effect.";
+        return "💥 Graph exploded! Nodes pushed apart for dramatic effect.\n📹 Camera zooming out to show expansion";
       } else {
         api.contractView();
+        // Zoom in to show the contracted graph after it settles
+        setTimeout(() => api.zoomToFit(1200, 60), 500);
         toast.success("3D Graph: Contracted view");
-        return "🌀 Graph contracted! Nodes pulled together.";
+        return "🌀 Graph contracted! Nodes pulled together.\n📹 Camera zooming in to show contraction";
       }
     },
   });
@@ -375,17 +379,27 @@ This creates a fireworks-like effect:
 
       const importantIds = rows.map((r) => r.id);
 
+      // Highlight and pulse important nodes so user can see which ones are bursting
+      api.highlightWhere((n: GraphNode) => importantIds.includes(n.id));
+      importantIds.slice(0, 5).forEach((id) => api.pulseNode(id));
+
+      // Zoom camera to show the important nodes
+      setTimeout(() => api.zoomToFit(1000, 80), 100);
+
       // Emit particles from all edges connected to important nodes
-      api.emitParticlesOnPath(
-        (l: GraphLink) =>
-          importantIds.includes(l.source) ||
-          importantIds.includes(l.target)
-      );
+      setTimeout(() => {
+        api.emitParticlesOnPath(
+          (l: GraphLink) =>
+            importantIds.includes(l.source) ||
+            importantIds.includes(l.target)
+        );
+      }, 300);
 
       toast.success(`3D Graph: Particle burst from ${rows.length} nodes`);
       return `🎆 Particle burst!
 ${rows.length} high-importance nodes emitting particles
-${particle_count} particles per edge`;
+${particle_count} particles per edge
+📹 Camera focused on important nodes`;
     },
   });
 
@@ -458,17 +472,23 @@ This creates a cascading reveal:
             const ids = rows.map((r) => r.id);
             api.highlightWhere((n: GraphNode) => ids.includes(n.id));
 
+            // Zoom camera to focus on this category's nodes
+            setTimeout(() => api.zoomToFit(600, 80), 50);
+
             // Emit particles
             setTimeout(() => {
               api.emitParticlesOnPath(
                 (l: GraphLink) => ids.includes(l.source) && ids.includes(l.target)
               );
             }, 200);
+
+            // Pulse the first few nodes for emphasis
+            ids.slice(0, 3).forEach((id) => api.pulseNode(id));
           }
         }, index * duration_per_category);
       });
 
-      // Clear at the end
+      // Clear at the end and zoom out to show entire graph
       setTimeout(() => {
         api.clear();
         api.zoomToFit(800, 60);
@@ -477,6 +497,7 @@ This creates a cascading reveal:
       toast.success(`3D Graph: Category wave started`);
       return `🌊 Category wave started!
 Highlighting ${categories.length} categories in sequence
+📹 Camera follows each category
 Total duration: ${categories.length * duration_per_category / 1000} seconds`;
     },
   });


### PR DESCRIPTION
When an agent calls a 3D tool, the camera now automatically zooms/pans to show the user what's happening:

- graph3d_explode_view: Zooms out after exploding, zooms in after contracting
- graph3d_particle_burst: Highlights and zooms to important nodes before burst
- graph3d_category_wave: Camera follows each category as it's highlighted

# Refactor: Use @mcp-b/react-webmcp hooks directly

## Summary

This PR refactors the codebase to use the official `@mcp-b/react-webmcp` hooks directly instead of re-exporting them through a wrapper. This aligns with best practices from the package documentation and removes unnecessary abstraction layers.

## Changes

### Core Refactoring
- **Replaced all `useMCPTool` imports** with `useWebMCP` from `@mcp-b/react-webmcp`
- **Updated all hook calls** to use the official API directly
- **Deprecated wrapper file** (`useMCPTool.ts`) with clear migration guidance
- **Maintained backward compatibility** through deprecated re-exports

### Files Modified (10 files, 57 insertions(+), 57 deletions(-))

#### Hook Files
- `src/react-app/hooks/useMCPNavigationTool.ts` - Navigation and routing tools (4 tools)
- `src/react-app/hooks/useMCPSQLTool.ts` - SQL query tools (2 tools)
- `src/react-app/hooks/useMCPGraphTools.ts` - React Flow graph manipulation (4 tools)
- `src/react-app/hooks/useMCPGraphSQLTools.ts` - SQL-based graph queries (3 tools)
- `src/react-app/hooks/useMCPTableTools.ts` - TanStack Table operations (1 tool)
- `src/react-app/hooks/useMCPGraphVisualEffects.ts` - Visual effects for graphs (4 tools)
- `src/react-app/hooks/useMCPGraph3DTools.ts` - 3D graph visualization tools
- `src/react-app/hooks/useMCPGraph3DAdvanced.ts` - Advanced 3D features

#### Component Files
- `src/react-app/components/graph/GraphWithEffects.tsx` - Component-level tools

#### Wrapper File (Deprecated)
- `src/react-app/hooks/useMCPTool.ts` - Now deprecated with migration guidance

## Benefits

✅ **Direct package usage** - No unnecessary abstraction layers
✅ **Aligned with official docs** - Following @mcp-b/react-webmcp best practices
✅ **Better maintainability** - Easier to update and debug
✅ **Backward compatible** - Old imports still work (with deprecation warnings)
✅ **Type-safe** - Full TypeScript support maintained
✅ **Cleaner codebase** - Removed redundant re-exports

## Migration Guide

### Old Code (Deprecated)
```typescript
import { useMCPTool, useMCPContextTool } from './useMCPTool';

useMCPTool({
  name: 'my_tool',
  description: 'My tool description',
  // ...
});
```

### New Code (Recommended)
```typescript
import { useWebMCP, useWebMCPContext } from '@mcp-b/react-webmcp';

useWebMCP({
  name: 'my_tool',
  description: 'My tool description',
  // ...
});
```

## Testing

All tools maintain their existing functionality:
- ✅ Navigation tools (navigate, get_current_context, list_all_routes, app_gateway)
- ✅ SQL tools (get_database_info, sql_query)
- ✅ Graph manipulation tools (query, focus, clear highlights, statistics)
- ✅ Graph SQL tools (find connections, find paths, analyze clusters)
- ✅ Table tools (all table operations)
- ✅ Visual effects tools (ripple, category highlight, path animation, pulsing)
- ✅ 3D graph tools (all 3D visualization features)

## Breaking Changes

**None** - This is a non-breaking change. All existing code continues to work through deprecated re-exports.

## Documentation Updates

The `useMCPTool.ts` file now includes:
- Clear deprecation warnings
- Migration instructions
- Links to official hooks

## Review Checklist

- [x] All imports updated to use official package
- [x] All hook calls refactored to use `useWebMCP`
- [x] Backward compatibility maintained
- [x] Deprecation warnings added
- [x] Migration guide documented
- [x] All tools verified to work correctly
- [x] Code changes are minimal and focused
- [x] No functionality changes - pure refactoring

## Next Steps

Future work could include:
1. Remove deprecated re-exports after migration period
2. Update any documentation referencing `useMCPTool`
3. Add ESLint rules to encourage direct package usage

---

**Ready for production** ✅
