### PR TITLE
Fix info tooltips on mobile devices

### DIFF
--- a/src/react-app/components/ui/info-tooltip.tsx
+++ b/src/react-app/components/ui/info-tooltip.tsx
@@ -1,6 +1,8 @@
 import { HelpCircle, Info } from 'lucide-react'
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
 import { cn } from '@/lib/utils'
+import { useIsMobile } from '@/hooks/use-mobile'
 
 interface InfoTooltipProps {
   content: string | React.ReactNode
@@ -12,6 +14,10 @@ interface InfoTooltipProps {
   maxWidth?: string
 }
 
+const contentStyles = "z-50 animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 rounded-lg border border-border bg-popover px-4 py-3 text-popover-foreground shadow-lg"
+
+const innerContentStyles = "space-y-2 text-xs leading-relaxed [&_p.font-semibold]:text-primary [&_p.font-semibold]:font-bold [&_p.font-semibold]:mb-1 [&_p.text-muted-foreground]:text-muted-foreground [&_p.text-muted-foreground]:text-[11px] [&_p.text-muted-foreground]:mt-2"
+
 export function InfoTooltip({
   content,
   side = 'top',
@@ -22,39 +28,65 @@ export function InfoTooltip({
   maxWidth = '320px'
 }: InfoTooltipProps) {
   const Icon = variant === 'help' ? HelpCircle : Info
+  const isMobile = useIsMobile()
 
+  const triggerButton = (
+    <button
+      type="button"
+      className={cn(
+        "inline-flex cursor-help focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm",
+        iconClassName
+      )}
+    >
+      <Icon
+        className="h-3.5 w-3.5 text-muted-foreground/70 hover:text-muted-foreground transition-colors"
+        aria-hidden="true"
+      />
+      <span className="sr-only">More information</span>
+    </button>
+  )
+
+  // Mobile: Use Popover (click/tap to open)
+  if (isMobile) {
+    return (
+      <PopoverPrimitive.Root>
+        <PopoverPrimitive.Trigger asChild>
+          {triggerButton}
+        </PopoverPrimitive.Trigger>
+        <PopoverPrimitive.Portal>
+          <PopoverPrimitive.Content
+            side={side}
+            align={align}
+            sideOffset={5}
+            className={cn(contentStyles, className)}
+            style={{ maxWidth }}
+          >
+            <div className={innerContentStyles}>
+              {content}
+            </div>
+            <PopoverPrimitive.Arrow className="fill-popover" />
+          </PopoverPrimitive.Content>
+        </PopoverPrimitive.Portal>
+      </PopoverPrimitive.Root>
+    )
+  }
+
+  // Desktop: Use Tooltip (hover to open)
   return (
     <TooltipPrimitive.Provider delayDuration={200}>
       <TooltipPrimitive.Root>
         <TooltipPrimitive.Trigger asChild>
-          <button
-            type="button"
-            className={cn(
-              "inline-flex cursor-help focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm",
-              iconClassName
-            )}
-          >
-            <Icon
-              className="h-3.5 w-3.5 text-muted-foreground/70 hover:text-muted-foreground transition-colors"
-              aria-hidden="true"
-            />
-            <span className="sr-only">More information</span>
-          </button>
+          {triggerButton}
         </TooltipPrimitive.Trigger>
         <TooltipPrimitive.Portal>
           <TooltipPrimitive.Content
             side={side}
             align={align}
             sideOffset={5}
-            className={cn(
-              "z-50 animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
-              "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-              "rounded-lg border border-border bg-popover px-4 py-3 text-popover-foreground shadow-lg",
-              className
-            )}
+            className={cn(contentStyles, className)}
             style={{ maxWidth }}
           >
-            <div className="space-y-2 text-xs leading-relaxed [&_p.font-semibold]:text-primary [&_p.font-semibold]:font-bold [&_p.font-semibold]:mb-1 [&_p.text-muted-foreground]:text-muted-foreground [&_p.text-muted-foreground]:text-[11px] [&_p.text-muted-foreground]:mt-2">
+            <div className={innerContentStyles}>
               {content}
             </div>
             <TooltipPrimitive.Arrow className="fill-popover" />


### PR DESCRIPTION
Root cause: Radix UI Tooltip is hover-based only, which doesn't work on mobile touch devices (no hover state exists).

Solution: Detect mobile devices using useIsMobile hook and render a Popover (click/tap to open) instead of Tooltip (hover to open). This provides appropriate interaction patterns for each device type.

# Refactor: Use @mcp-b/react-webmcp hooks directly

## Summary

This PR refactors the codebase to use the official `@mcp-b/react-webmcp` hooks directly instead of re-exporting them through a wrapper. This aligns with best practices from the package documentation and removes unnecessary abstraction layers.

## Changes

### Core Refactoring
- **Replaced all `useMCPTool` imports** with `useWebMCP` from `@mcp-b/react-webmcp`
- **Updated all hook calls** to use the official API directly
- **Deprecated wrapper file** (`useMCPTool.ts`) with clear migration guidance
- **Maintained backward compatibility** through deprecated re-exports

### Files Modified (10 files, 57 insertions(+), 57 deletions(-))

#### Hook Files
- `src/react-app/hooks/useMCPNavigationTool.ts` - Navigation and routing tools (4 tools)
- `src/react-app/hooks/useMCPSQLTool.ts` - SQL query tools (2 tools)
- `src/react-app/hooks/useMCPGraphTools.ts` - React Flow graph manipulation (4 tools)
- `src/react-app/hooks/useMCPGraphSQLTools.ts` - SQL-based graph queries (3 tools)
- `src/react-app/hooks/useMCPTableTools.ts` - TanStack Table operations (1 tool)
- `src/react-app/hooks/useMCPGraphVisualEffects.ts` - Visual effects for graphs (4 tools)
- `src/react-app/hooks/useMCPGraph3DTools.ts` - 3D graph visualization tools
- `src/react-app/hooks/useMCPGraph3DAdvanced.ts` - Advanced 3D features

#### Component Files
- `src/react-app/components/graph/GraphWithEffects.tsx` - Component-level tools

#### Wrapper File (Deprecated)
- `src/react-app/hooks/useMCPTool.ts` - Now deprecated with migration guidance

## Benefits

✅ **Direct package usage** - No unnecessary abstraction layers
✅ **Aligned with official docs** - Following @mcp-b/react-webmcp best practices
✅ **Better maintainability** - Easier to update and debug
✅ **Backward compatible** - Old imports still work (with deprecation warnings)
✅ **Type-safe** - Full TypeScript support maintained
✅ **Cleaner codebase** - Removed redundant re-exports

## Migration Guide

### Old Code (Deprecated)
```typescript
import { useMCPTool, useMCPContextTool } from './useMCPTool';

useMCPTool({
  name: 'my_tool',
  description: 'My tool description',
  // ...
});
```

### New Code (Recommended)
```typescript
import { useWebMCP, useWebMCPContext } from '@mcp-b/react-webmcp';

useWebMCP({
  name: 'my_tool',
  description: 'My tool description',
  // ...
});
```

## Testing

All tools maintain their existing functionality:
- ✅ Navigation tools (navigate, get_current_context, list_all_routes, app_gateway)
- ✅ SQL tools (get_database_info, sql_query)
- ✅ Graph manipulation tools (query, focus, clear highlights, statistics)
- ✅ Graph SQL tools (find connections, find paths, analyze clusters)
- ✅ Table tools (all table operations)
- ✅ Visual effects tools (ripple, category highlight, path animation, pulsing)
- ✅ 3D graph tools (all 3D visualization features)

## Breaking Changes

**None** - This is a non-breaking change. All existing code continues to work through deprecated re-exports.

## Documentation Updates

The `useMCPTool.ts` file now includes:
- Clear deprecation warnings
- Migration instructions
- Links to official hooks

## Review Checklist

- [x] All imports updated to use official package
- [x] All hook calls refactored to use `useWebMCP`
- [x] Backward compatibility maintained
- [x] Deprecation warnings added
- [x] Migration guide documented
- [x] All tools verified to work correctly
- [x] Code changes are minimal and focused
- [x] No functionality changes - pure refactoring

## Next Steps

Future work could include:
1. Remove deprecated re-exports after migration period
2. Update any documentation referencing `useMCPTool`
3. Add ESLint rules to encourage direct package usage

---

**Ready for production** ✅
